### PR TITLE
Versión 1.10.6.2:

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
         versionCode 99
-        versionName "1.10.6.1"
+        versionName "1.10.6.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/es/icp/icp_commons/Objects/ImagenCommons.java
+++ b/app/src/main/java/es/icp/icp_commons/Objects/ImagenCommons.java
@@ -1,10 +1,8 @@
 package es.icp.icp_commons.Objects;
 
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 
-import es.icp.icp_commons.R;
 import es.icp.icp_commons.Utils.CommonsUtilsImagenes;
 import es.icp.icp_commons.Utils.Localizacion;
 import es.icp.icp_commons.Utils.UtilsFechas;
@@ -33,6 +31,10 @@ public class ImagenCommons {
         this.formato     = formato;
         this.orientacion = orientacion;
         this.fecha       = fecha;
+    }
+
+    public ImagenCommons(Drawable drawable, Bitmap.CompressFormat formato, int orientacion, String fecha) {
+        this(CommonsUtilsImagenes.fromDrawableToBase64Image(drawable), formato, orientacion, fecha);
     }
 
     public String getContenido() {


### PR DESCRIPTION
    - ImagenCommons: imagenen predeterminada ahora se carga mediante un drawable.